### PR TITLE
Fix authentication failure issue

### DIFF
--- a/linux_sql/scripts/psql_docker.sh
+++ b/linux_sql/scripts/psql_docker.sh
@@ -30,15 +30,16 @@ elif [ "$op" = "start" ]; then
         fi
         # check if `jrvs-psql` container is created
         if [ $(docker ps -a -f name=jrvs-psql | wc -l) -ne 2 ]; then
-            echo "creating container..."
-            docker create \
+            echo "starting container..." 
+            docker run \
             --name jrvs-psql \
             -e POSTGRES_PASSWORD=$pwd \
             -v pgdata:/var/lib/postgresql/data \
             -p 5432:5432 \
-            postgres
+            -d postgres
+        else
+            docker container start jrvs-psql
         fi
-        docker container start jrvs-psql
     fi
 else
     >&2 echo "error: '${op}' is not a valid operation"

--- a/linux_sql/scripts/psql_docker.sh
+++ b/linux_sql/scripts/psql_docker.sh
@@ -11,7 +11,7 @@ if [ "$op" = "stop" ]; then
     docker stop jrvs-psql
 elif [ "$op" = "start" ]; then
     if [ -z "$pwd" ]; then
-        echo "error: please provide a postgres password"
+        >&2 echo "error: please provide a postgres password"
         exit 1
     fi
     # systemctl status docker || systemctl start docker 
@@ -41,8 +41,8 @@ elif [ "$op" = "start" ]; then
         docker container start jrvs-psql 
     fi
 else
-    echo "error: '${op}' is not a valid command"
-    exit 1
+    >&2 echo "error: '${op}' is not a valid command"
+    exit 127
 fi
 
 exit 0


### PR DESCRIPTION
For some unclear reasons user was not able to connect the psql-server if the container is first created then started (`docker create `+ `docker container start`) in the case when _jrvs-psql_ container hasn't been created. Directly using `docker run` will avoid this issue. 